### PR TITLE
Fix invalid scope in admin edit order template

### DIFF
--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -17,7 +17,7 @@
   <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @order } %>
 </div>
 
-<% if @order.payments.exists? && @order.considered_risky? %>
+<% if @order.payments.valid.any? && @order.considered_risky? %>
   <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.valid.last %>
 <% end %>
 


### PR DESCRIPTION
When order hasn't any valid payment, it renders a partial passing nil value for latest_payment variable.

Note: already proposed and merged on 2-4-stable branch.
